### PR TITLE
Fixes `link_to_post` notice (occurs when saving settings and WP_DEBUG…

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -702,7 +702,7 @@ class Post_Views_Counter_Settings {
 			$input['display_style']['text'] = (isset( $input['display_style']['text'] ) ? true : false);
 
 			// link to post
-			$input['link_to_post'] = (isset( $input['link_to_post'] ) ? (bool) $input['link_to_post'] : Post_Views_Counter()->get_attribute( 'defaults', 'general', 'link_to_post' ));
+			$input['link_to_post'] = (isset( $input['link_to_post'] ) ? (bool) $input['link_to_post'] : Post_Views_Counter()->get_attribute( 'defaults', 'display', 'link_to_post' ));
 
 			// icon class
 			$input['icon_class'] = (isset( $input['icon_class'] ) ? trim( $input['icon_class'] ) : Post_Views_Counter()->get_attribute( 'defaults', 'general', 'icon_class' ));


### PR DESCRIPTION
… is true).

`link_to_post` is in `display` group in `Post_Views_Counter::$defaults`, not in `general`.

Exact notice was: `PHP Notice:  Undefined index: link_to_post in post-views-counter.php on line 239`