### PR TITLE
Fixing a PHP7 warning on implode function call

### DIFF
--- a/includes/crawler-detect.php
+++ b/includes/crawler-detect.php
@@ -5,10 +5,10 @@ if ( ! defined( 'ABSPATH' ) )
 
 /**
  * Post_Views_Counter_Crawler_Detect class.
- * 
+ *
  * Based on CrawlerDetect php class adjusted to PHP 5.2
  * https://github.com/JayBizzle/Crawler-Detect/blob/master/src/CrawlerDetect.php
- * 
+ *
  * @since 1.2.4
  * @class Post_Views_Counter_Crawler_Detect
  */
@@ -40,14 +40,14 @@ class Post_Views_Counter_Crawler_Detect {
 	 *
 	 * @var object
 	 */
-	protected $crawlers;
+	protected $crawlers = array();
 
 	/**
 	 * Exclusions object.
 	 *
 	 * @var object
 	 */
-	protected $exclusions;
+	protected $exclusions = array();
 
 	/**
 	 * Headers object.
@@ -60,6 +60,9 @@ class Post_Views_Counter_Crawler_Detect {
 	 * Class constructor.
 	 */
 	public function __construct() {
+		$this->crawlers = $this->get_crawlers_list();
+		$this->exclusions = $this->get_exclusions_list();
+
 		add_action( 'after_setup_theme', array( $this, 'init' ) );
 	}
 
@@ -71,8 +74,6 @@ class Post_Views_Counter_Crawler_Detect {
 		if ( is_admin() && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) )
 			return;
 
-		$this->crawlers = $this->get_crawlers_list();
-		$this->exclusions = $this->get_exclusions_list();
 		$this->ua_http_headers = $this->get_headers_list();
 		$this->set_http_headers();
 		$this->set_user_agent();


### PR DESCRIPTION
We've also noticed in our logs that there are errors similar to the following (this has been changed to protect the innocent):

```
PHP Warning:  implode(): Invalid arguments passed in /path/to/site/wp-content/plugins/post-views-counter/includes/crawler-detect.php on line 153, referer: http://localhost/path/to/page/
```

It seems there is a race condition where the calls to `get_exclusions` and `get_regex` can happen before `init` is called.

This same problem has been mentioned here:

https://wordpress.org/support/topic/php-warning-189/

This pull request sets the member variables for `$crawlers` and `$exclusions` to arrays as soon as they are declared. It also moves the calls `get_crawlers_list` and `get_exclusions_list` to the constructor to guarantee that the member variables have values before they are be used.