### PR TITLE
Fix counter to be recorded in right period

### DIFF
--- a/includes/counter.php
+++ b/includes/counter.php
@@ -418,11 +418,11 @@ class Post_Views_Counter_Counter {
 		$increment_amount = (int) apply_filters( 'pvc_views_increment_amount', 1, $id );
 
 		// get day, week, month and year
-		$date = explode( '-', date( 'W-d-m-Y', current_time( 'timestamp' ,true ) ) );
+		$date = explode( '-', date( 'W-d-m-Y-o', current_time( 'timestamp' ,true ) ) );
 
 		foreach ( array(
 			0	 => $date[3] . $date[2] . $date[1], // day like 20140324
-			1	 => $date[3] . $date[0], // week like 201439
+			1	 => $date[4] . $date[0], // week like 201439
 			2	 => $date[3] . $date[2], // month like 201405
 			3	 => $date[3], // year like 2014
 			4	 => 'total'   // total views

--- a/includes/counter.php
+++ b/includes/counter.php
@@ -418,7 +418,7 @@ class Post_Views_Counter_Counter {
 		$increment_amount = (int) apply_filters( 'pvc_views_increment_amount', 1, $id );
 
 		// get day, week, month and year
-		$date = explode( '-', date( 'W-d-m-Y', current_time( 'timestamp' ) ) );
+		$date = explode( '-', date( 'W-d-m-Y', current_time( 'timestamp' ,true ) ) );
 
 		foreach ( array(
 			0	 => $date[3] . $date[2] . $date[1], // day like 20140324


### PR DESCRIPTION
`date()` expects that 2nd argment is UTC timestamp and return as local time.
Then, passing local timestamp result in double timezone offset.

Year of the week may be different than year of the date, so it must be handled differently.