### PR TITLE
Add apply_filters on available post types

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -120,6 +120,8 @@ class Post_Views_Counter_Settings {
 			$post_types[$key] = $post_type->labels->name;
 		}
 
+        $post_types = apply_filters('pvc_available_post_types', $post_types);
+
 		// sort post types alphabetically with their keys
 		asort( $post_types, SORT_STRING );
 


### PR DESCRIPTION
It is useful to have the ability to add post_type in the case where we want not public post type to be countable. 

My modification is perfectly compatible without any change from the user.