### PR TITLE
Added unit to the option

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -239,6 +239,16 @@ class Post_Views_Counter_Settings {
 					'validate'		=> [ $this, 'validate_label' ],
 					'reset'			=> [ $this, 'reset_label' ]
 				],
+                'unit' => [
+                    'tab'           => 'display',
+                    'title'         => __( 'Units', 'post-view-counter' ),
+                    'section'       => 'post_views_counter_display_settings',
+                    'type'			=> 'input',
+                    'description'	=> __( 'Enter the unit for the post views counter field.', 'post-views-counter' ),
+                    'subclass'		=> 'regular-text',
+                    'validate'		=> [ $this, 'validate_unit' ],
+                    'reset'			=> [ $this, 'reset_unit' ]
+                ],
 				'post_types_display' => [
 					'tab'			=> 'display',
 					'title'			=> __( 'Post Type', 'post-views-counter' ),
@@ -446,6 +456,29 @@ class Post_Views_Counter_Settings {
 		return $input;
 	}
 
+    /**
+     * Validate unit.
+     *
+     * @param array $input Input POST data
+     * @param array $field Field options
+     * @return array
+     */
+    public function validate_unit( $input, $field ) {
+        // get main instance
+        $pvc = Post_Views_Counter();
+
+        if ( ! isset( $input ) )
+            $input = $pvc->defaults['display']['unit'];
+
+        // use internal settings API to validate settings first
+        $input = $pvc->settings_api->validate_field( $input, 'input', $field );
+
+        if ( function_exists( 'icl_register_string' ) )
+            icl_register_string( 'Post Views Counter', 'Post Views Unit', $input );
+
+        return $input;
+    }
+
 	/**
 	 * Restore post views label to default value.
 	 *
@@ -459,6 +492,20 @@ class Post_Views_Counter_Settings {
 
 		return $default;
 	}
+
+    /**
+     * Restore post views unit to default value.
+     *
+     * @param array $default Default value
+     * @param array $field Field options
+     * @return array
+     */
+    public function reset_unit( $default, $field ) {
+        if ( function_exists( 'icl_register_string' ) )
+            icl_register_string( 'Post Views Counter', 'Post Views Unit', $default );
+
+        return $default;
+    }
 
 	/**
 	 * Setting: display style.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -404,6 +404,9 @@ if ( ! function_exists( 'pvc_post_views' ) ) {
 		// prepare display
 		$label = apply_filters( 'pvc_post_views_label', ( function_exists( 'icl_t' ) ? icl_t( 'Post Views Counter', 'Post Views Label', $options['label'] ) : $options['label'] ), $post_id );
 
+        // prepare unit
+        $unit = apply_filters( 'pvc_post_views_unit', ( function_exists('icl_t') ? icl_t( 'Post Views Counter', 'Post Views Label', $options['unit'] ) : $options['unit']), $post_id );
+
 		// get icon class
 		$icon_class = ( $options['icon_class'] !== '' ? esc_attr( $options['icon_class'] ) : '' );
 
@@ -418,7 +421,7 @@ if ( ! function_exists( 'pvc_post_views' ) ) {
 			'<div class="' . esc_attr( $class ) . '">
 				' . ( $options['display_style']['icon'] && $icon_class !== '' ? $icon : '' )
 				. ( $options['display_style']['text'] && $label !== '' ? '<span class="post-views-label">' . esc_html( $label ) . '</span> ' : '' )
-				. '<span class="post-views-count">' . number_format_i18n( $views ) . '</span>
+				. '<span class="post-views-count">' . number_format_i18n( $views ) . '</span> ' . $unit . '
 			</div>',
 			$post_id,
 			$views,

--- a/post-views-counter.php
+++ b/post-views-counter.php
@@ -70,6 +70,7 @@ if ( ! class_exists( 'Post_Views_Counter' ) ) {
 			],
 			'display'	=> [
 				'label'					=> 'Post Views:',
+                'unit'                  => '',
 				'post_types_display'	=> [ 'post' ],
 				'page_types_display'	=> [ 'singular' ],
 				'restrict_display'		=> [


### PR DESCRIPTION
Unfortunately, I cannot find any pull request template. But these are details I could provide:

# Background
 
I want to add unit to be shown after the number like follows:

<img width="697" alt="image" src="https://user-images.githubusercontent.com/10561001/163057536-db907cac-cbd6-4aeb-b4ce-2352f89ab791.png">

In example above, the unit shall be `Orang`.

# Explanation

My solution will be to add new option field to the setting and append the unit to the text. 
